### PR TITLE
Allow any SPiiPlus user units

### DIFF
--- a/acsMotionApp/src/SPiiPlusDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusDriver.cpp
@@ -808,11 +808,11 @@ std::string SPiiPlusController::positionsToString(int positionIndex)
     
     if (profileAxes_[i] == profileAxes_.front())
     {
-      outputStr << lround(pAxis->fullProfilePositions_[positionIndex]);
+      outputStr << pAxis->fullProfilePositions_[positionIndex];
     }
     else 
     {
-      outputStr << ',' << lround(pAxis->fullProfilePositions_[positionIndex]);
+      outputStr << ',' << pAxis->fullProfilePositions_[positionIndex];
     }
   }
   

--- a/acsMotionApp/src/SPiiPlusDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusDriver.cpp
@@ -61,6 +61,12 @@ SPiiPlusController::SPiiPlusController(const char* ACSPortName, const char* asyn
 		writeReadInt(cmd, &(pAxes_[index]->mflags_));
 		// Bit 0 is #DUMMY
 		pAxes_[index]->dummy_ = (pAxes_[index]->mflags_) & (1 << 0);
+		// Bit 4 is #STEPPER
+		pAxes_[index]->stepper_ = (pAxes_[index]->mflags_) & (1 << 4);
+		// Bit 5 is #ENCLOOP
+		pAxes_[index]->encloop_ = (pAxes_[index]->mflags_) & (1 << 5);
+		// Bit 6 is #STEPENC
+		pAxes_[index]->stepenc_ = (pAxes_[index]->mflags_) & (1 << 6);
 		
 		// Query the axis resolution (used to convert motor record steps into controller EGU)
 		cmd << "?STEPF(" << index << ")";
@@ -694,7 +700,10 @@ void SPiiPlusAxis::report(FILE *fp, int level)
   
   fprintf(fp, "Configuration for axis %i:\n", axisNo_);
   fprintf(fp, "  mflags: %i\n", mflags_);
-  fprintf(fp, "  dummy:  %i\n", dummy_);
+  fprintf(fp, "    dummy:  %i\n", dummy_);
+  fprintf(fp, "    stepper:  %i\n", stepper_);
+  fprintf(fp, "    encloop:  %i\n", encloop_);
+  fprintf(fp, "    stepenc:  %i\n", stepenc_);
   fprintf(fp, "  moving: %i\n", moving_);
   fprintf(fp, "  resolution: %lf\n", resolution_);
   fprintf(fp, "  encoder resolution: %lf\n", encoderResolution_);

--- a/acsMotionApp/src/SPiiPlusDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusDriver.cpp
@@ -688,6 +688,30 @@ asynStatus SPiiPlusAxis::home(double minVelocity, double maxVelocity, double acc
 	return status;
 }
 
+/** Function to define the motor positions for a profile move. 
+  * Called by asynMotorController::writeFloat64Array
+  * This calls the base class defineProfile method to convert to steps, but since the
+  * SPiiPlus works in user-units we need to do an additional conversion by resolution_. 
+  * \param[in] positions Array of profile positions for this axis in user units.
+  * \param[in] numPoints The number of positions in the array.
+  */
+asynStatus SPiiPlusAxis::defineProfile(double *positions, size_t numPoints)
+{
+  size_t i;
+  asynStatus status;
+  //static const char *functionName = "defineProfile";
+  
+  // Call the base class function (converts from EGU to steps)
+  status = asynMotorAxis::defineProfile(positions, numPoints);
+  if (status) return status;
+  
+  // Convert from steps to SPiiPlus user units
+  for (i=0; i<numPoints; i++) {
+    profilePositions_[i] = profilePositions_[i]*resolution_;
+  }
+  return asynSuccess;
+}
+
 /** Reports on status of the axis
   * \param[in] fp The file pointer on which report information will be written
   * \param[in] level The level of report detail desired
@@ -872,6 +896,7 @@ asynStatus SPiiPlusController::buildProfile()
             "%s:%s: entry\n",
             driverName, functionName);
             
+
   // Call the base class method which will build the time array if needed
   asynMotorController::buildProfile();
   

--- a/acsMotionApp/src/SPiiPlusDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusDriver.cpp
@@ -61,6 +61,17 @@ SPiiPlusController::SPiiPlusController(const char* ACSPortName, const char* asyn
 		writeReadInt(cmd, &(pAxes_[index]->mflags_));
 		// Bit 0 is #DUMMY
 		pAxes_[index]->dummy_ = (pAxes_[index]->mflags_) & (1 << 0);
+		
+		// Query the axis resolution (used to convert motor record steps into controller EGU)
+		cmd << "?STEPF(" << index << ")";
+		writeReadDouble(cmd, &(pAxes_[index]->resolution_));
+		
+		// Query the encoder resolution (not currently used for anything)
+		cmd << "?EFAC(" << index << ")";
+		writeReadDouble(cmd, &(pAxes_[index]->encoderResolution_));
+		// Query the encoder offset (not currently used for anything)
+		cmd << "?EOFFS(" << index << ")";
+		writeReadDouble(cmd, &(pAxes_[index]->encoderOffset_));
 	}
 	
 	this->startPoller(movingPollPeriod, idlePollPeriod, 2);
@@ -685,6 +696,9 @@ void SPiiPlusAxis::report(FILE *fp, int level)
   fprintf(fp, "  mflags: %i\n", mflags_);
   fprintf(fp, "  dummy:  %i\n", dummy_);
   fprintf(fp, "  moving: %i\n", moving_);
+  fprintf(fp, "  resolution: %lf\n", resolution_);
+  fprintf(fp, "  encoder resolution: %lf\n", encoderResolution_);
+  fprintf(fp, "  encoder offset: %lf\n", encoderOffset_);
   fprintf(fp, "  homing method: %i\n", homingMethod);
   fprintf(fp, "\n");
   

--- a/acsMotionApp/src/SPiiPlusDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusDriver.cpp
@@ -705,8 +705,8 @@ void SPiiPlusAxis::report(FILE *fp, int level)
   fprintf(fp, "    encloop:  %i\n", encloop_);
   fprintf(fp, "    stepenc:  %i\n", stepenc_);
   fprintf(fp, "  moving: %i\n", moving_);
-  fprintf(fp, "  resolution: %lf\n", resolution_);
-  fprintf(fp, "  encoder resolution: %lf\n", encoderResolution_);
+  fprintf(fp, "  resolution: %.6e\n", resolution_);
+  fprintf(fp, "  encoder resolution: %.6e\n", encoderResolution_);
   fprintf(fp, "  encoder offset: %lf\n", encoderOffset_);
   fprintf(fp, "  homing method: %i\n", homingMethod);
   fprintf(fp, "\n");

--- a/acsMotionApp/src/SPiiPlusDriver.h
+++ b/acsMotionApp/src/SPiiPlusDriver.h
@@ -88,8 +88,11 @@ private:
 	double profileStartPos_;
 	double profileFlybackPos_;
 	int moving_;
-	int mflags_;
+	int mflags_;			// MFLAGS
 	int dummy_;
+	double resolution_;		// STEPF
+	double encoderResolution_;	// EFAC
+	double encoderOffset_;		// EOFFS
 	
 friend class SPiiPlusController;
 };

--- a/acsMotionApp/src/SPiiPlusDriver.h
+++ b/acsMotionApp/src/SPiiPlusDriver.h
@@ -75,7 +75,7 @@ public:
 	asynStatus poll(bool *moving);
 	asynStatus setPosition(double position);
 	asynStatus setClosedLoop(bool closedLoop);
-	
+	asynStatus defineProfile(double *positions, size_t numPoints);
 	
 private:
 	SPiiPlusController *pC_;	/**< Pointer to the asynMotorController to which this axis belongs.

--- a/acsMotionApp/src/SPiiPlusDriver.h
+++ b/acsMotionApp/src/SPiiPlusDriver.h
@@ -89,7 +89,10 @@ private:
 	double profileFlybackPos_;
 	int moving_;
 	int mflags_;			// MFLAGS
-	int dummy_;
+	int dummy_;			// MFLAGS, bit 0
+	int stepper_;			// MFLAGS, bit 4
+	int encloop_;			// MFLAGS, bit 5
+	int stepenc_;			// MFLAGS, bit 6
 	double resolution_;		// STEPF
 	double encoderResolution_;	// EFAC
 	double encoderOffset_;		// EOFFS


### PR DESCRIPTION
The driver previously assumed the user unit was steps.  This PR queries the STEPF to get the axis resolution, which avoids the need to specify an axis resolution in a .cmd file.