### PR TITLE
Added include statements required for calloc and malloc on RHEL7

### DIFF
--- a/acsMotionApp/src/SPiiPlusAuxDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusAuxDriver.cpp
@@ -1,4 +1,5 @@
 
+#include <stdlib.h>
 #include <sstream>
 
 #include <iocsh.h>

--- a/acsMotionApp/src/SPiiPlusCommDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusCommDriver.cpp
@@ -1,5 +1,6 @@
 
 #include <string.h>
+#include <cstdlib>
 #include <sstream>
 
 #include <iocsh.h>


### PR DESCRIPTION
Fixes #24 