### PR TITLE
Fix memory leak of packet buffers

### DIFF
--- a/acsMotionApp/src/SPiiPlusCommDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusCommDriver.cpp
@@ -281,6 +281,9 @@ asynStatus SPiiPlusComm::writeReadBinary(char *output, int outBytes, char *input
 	// Restore the EOS characters
 	pasynOctetSyncIO->setInputEos(pasynUserComm_, "\r", 1);
 	pasynOctetSyncIO->setOutputEos(pasynUserComm_, "\r", 1);
+
+	// Free up allocated memory
+	free(packetBuffer);
 	
 	unlock();
 	


### PR DESCRIPTION
We found a serious memory leak in the comm driver code.  It looked pretty simple to fix.  I've tested it on our system for a few hours now and the memory footprint has held at around 8MB.