### PR TITLE
Fixes for building on Windows

### DIFF
--- a/acsMotionApp/src/SPiiPlusAuxDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusAuxDriver.cpp
@@ -4,9 +4,12 @@
 
 #include <iocsh.h>
 #include <epicsThread.h>
-#include <epicsExport.h>
 
-#include <asynPortDriver.h>
+// asynMotorController.h includes asynPortDriver.h
+#include <asynMotorController.h>
+#include <asynMotorAxis.h>
+
+#include <epicsExport.h>
 
 #include "SPiiPlusAuxDriver.h"
 

--- a/acsMotionApp/src/SPiiPlusAuxDriver.h
+++ b/acsMotionApp/src/SPiiPlusAuxDriver.h
@@ -18,7 +18,7 @@
 #define analogInputString         "ANALOG_INPUT"
 #define analogOutputString        "ANALOG_OUTPUT"
 
-class SPiiPlusAuxIO : public asynPortDriver {
+class epicsShareClass SPiiPlusAuxIO : public asynPortDriver {
 public:
   SPiiPlusAuxIO(const char *auxIOPortName, const char* asynPortName, int numChannels, double pollPeriod);
   ~SPiiPlusAuxIO();


### PR DESCRIPTION
Fixes for building on Windows:

1. Corrected order of include files in SPiiPlusAuxDriver.cpp
2. Added epicsShareClass to SPiiPlusAuxIO.

Conversation about these changes: https://github.com/epics-motor/motorAcsMotion/issues/32