### PR TITLE
Jog improvements

### DIFF
--- a/acsMotionApp/Db/SPiiPlusJogging.db
+++ b/acsMotionApp/Db/SPiiPlusJogging.db
@@ -1,7 +1,6 @@
-record(ao, "$(P)$(M):jogDirection")
+record(longout, "$(P)$(M):jogDirection")
 {
-    field(DTYP, "asynInt32")
-    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))SPIIPLUS_JOG_DIRECTION")
+    field(DTYP, "Soft Channel")
     field(DESC, "Jog Direction")
 }
 

--- a/acsMotionApp/src/SPiiPlusDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusDriver.cpp
@@ -818,19 +818,16 @@ asynStatus SPiiPlusAxis::moveVelocity(double minVelocity, double maxVelocity, do
 	epicsInt32 jogDirection;
 	controller->getIntegerParam(axisNo_, controller->SPiiPlusJogDirection_, &jogDirection);
 
-	//Factor speed to resolution but work at a sensible ramp up if MRES = 0.0001
-	cmd << "ACC(" << axisNo_ << ")=" << (acceleration * resolution_) * 10;
+	cmd << "ACC(" << axisNo_ << ")=" << (acceleration * resolution_);
 	status = controller->pComm_->writeReadAck(cmd);
 
-	cmd << "DEC(" << axisNo_ << ")=" << (abs(maxVelocity) * 10);
-	status = controller->pComm_->writeReadAck(cmd);
-
-	cmd << "VEL(" << axisNo_ << ")=" << (abs(maxVelocity) / 10);
+	cmd << "DEC(" << axisNo_ << ")=" << (acceleration * resolution_);
 	status = controller->pComm_->writeReadAck(cmd);
 
 	char motionDirection = maxVelocity > 0 ? '+' : '-';
 
-	cmd << "jog " << axisNo_ << ", " << motionDirection;
+	// Pass the jog velocity to the jog command, rather than change the normal velocity
+	cmd << "JOG/v " << axisNo_ << ", " << (abs(maxVelocity) * resolution_) << ", " << motionDirection;
 	status = controller->pComm_->writeReadAck(cmd);
 
 	return status;

--- a/acsMotionApp/src/SPiiPlusDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusDriver.cpp
@@ -57,7 +57,6 @@ SPiiPlusController::SPiiPlusController(const char* ACSPortName, const char* asyn
 	
 	// Create parameters
 	createParam(SPiiPlusHomingMethodString,               asynParamInt32, &SPiiPlusHomingMethod_);
-	createParam(SPiiPlusJogDirectionString,               asynParamInt32, &SPiiPlusJogDirection_);
 	createParam(SPiiPlusMaxVelocityString,                asynParamFloat64, &SPiiPlusMaxVelocity_);
 	createParam(SPiiPlusMaxAccelerationString,            asynParamFloat64, &SPiiPlusMaxAcceleration_);
 	createParam(SPiiPlusReadIntVarString,                 asynParamInt32,   &SPiiPlusReadIntVar_);
@@ -814,9 +813,6 @@ asynStatus SPiiPlusAxis::moveVelocity(double minVelocity, double maxVelocity, do
 	asynStatus status;
 	double deviceUnits;
 	std::stringstream cmd;
-
-	epicsInt32 jogDirection;
-	controller->getIntegerParam(axisNo_, controller->SPiiPlusJogDirection_, &jogDirection);
 
 	cmd << "ACC(" << axisNo_ << ")=" << (acceleration * resolution_);
 	status = controller->pComm_->writeReadAck(cmd);

--- a/acsMotionApp/src/SPiiPlusDriver.h
+++ b/acsMotionApp/src/SPiiPlusDriver.h
@@ -99,7 +99,6 @@
 
 // drvInfo strings for extra parameters that the XPS controller supports
 #define SPiiPlusHomingMethodString             "SPIIPLUS_HOMING_METHOD"
-#define SPiiPlusJogDirectionString             "SPIIPLUS_JOG_DIRECTION"
 #define SPiiPlusMaxVelocityString              "SPIIPLUS_MAX_VELOCITY"
 #define SPiiPlusMaxAccelerationString          "SPIIPLUS_MAX_ACCELERATION"
 #define SPiiPlusReadIntVarString               "SPIIPLUS_READ_INT_VAR"
@@ -233,7 +232,6 @@ protected:
 	
 	#define FIRST_SPIIPLUS_PARAM SPiiPlusHomingMethod_
 	int SPiiPlusHomingMethod_;
-	int SPiiPlusJogDirection_;
 	int SPiiPlusMaxVelocity_;
 	int SPiiPlusMaxAcceleration_;
 	int SPiiPlusReadIntVar_;

--- a/iocs/acsMotionIOC/acsMotionApp/Db/Makefile
+++ b/iocs/acsMotionIOC/acsMotionApp/Db/Makefile
@@ -49,6 +49,7 @@ DB_INSTALLS += $(MOTOR)/db/SPiiPlusAuxBo.db
 DB_INSTALLS += $(MOTOR)/db/SPiiPlusAuxLi.db
 DB_INSTALLS += $(MOTOR)/db/SPiiPlusAuxLo.db
 DB_INSTALLS += $(MOTOR)/db/SPiiPlusHoming.db
+DB_INSTALLS += $(MOTOR)/db/SPiiPlusJogging.db
 DB_INSTALLS += $(MOTOR)/db/SPiiPlusMaxParams.db
 DB_INSTALLS += $(MOTOR)/db/SPiiPlusMaxParamsRbv.db
 DB_INSTALLS += $(MOTOR)/db/SPiiPlusIntVar.db

--- a/iocs/acsMotionIOC/iocBoot/iocAcsMotion/AcsMotion.substitutions
+++ b/iocs/acsMotionIOC/iocBoot/iocAcsMotion/AcsMotion.substitutions
@@ -76,15 +76,15 @@ pattern
 file "$(TOP)/db/SPiiPlusJogging.db"
 {
 pattern
-{M,   PORT, ADDR, TIMEOUT,   VAL}
-{m1,  ACS1,    0, 2.0,       0}
-{m2,  ACS1,    1, 2.0,       0}
-{m3,  ACS1,    2, 2.0,       0}
-{m4,  ACS1,    3, 2.0,       0}
-{m5,  ACS1,    4, 2.0,       0}
-{m6,  ACS1,    5, 2.0,       0}
-{m7,  ACS1,    6, 2.0,       0}
-{m8,  ACS1,    7, 2.0,       0}
+{M}
+{m1}
+{m2}
+{m3}
+{m4}
+{m5}
+{m6}
+{m7}
+{m8}
 }
 
 # These records work, but the initial values are all zero.  Maybe HOPR/LOPR/DRVH/DRVL need to be set?


### PR DESCRIPTION
Changes:

1. Use the jog velocity (JVAL) and acceleration (JAR) 
2. Pass the jog velocity to the jog command rather than change the normal move velocity
3. Removed the unused jog direction parameter
4. Changed the jogDirection record from an ao to a longout