### PR TITLE
Allow PINI to be specified for global var output records

### DIFF
--- a/acsMotionApp/Db/SPiiPlusIntVar.db
+++ b/acsMotionApp/Db/SPiiPlusIntVar.db
@@ -5,6 +5,8 @@ record(longout, "$(P)$(R)")
     field(DTYP, "asynInt32")
     field(OUT,  "@asyn($(PORT),$(TAG),$(TIMEOUT=1))SPIIPLUS_WRITE_INT_VAR")
     field(FLNK, "$(P)$(R)_RBV")
+    # Only set PINI to YES if autosave is used
+    field(PINI, "$(PINI=NO)")
 }
 
 record(longin, "$(P)$(R)_RBV")

--- a/acsMotionApp/Db/SPiiPlusRealVar.db
+++ b/acsMotionApp/Db/SPiiPlusRealVar.db
@@ -6,6 +6,8 @@ record(ao, "$(P)$(R)")
     field(OUT,  "@asyn($(PORT),$(TAG),$(TIMEOUT=1))SPIIPLUS_WRITE_REAL_VAR")
     field(FLNK, "$(P)$(R)_RBV")
     field(PREC, "$(PREC=4)")
+    # Only set PINI to YES if autosave is used
+    field(PINI, "$(PINI=NO)")
 }
 
 record(ai, "$(P)$(R)_RBV")

--- a/iocs/acsMotionIOC/iocBoot/iocAcsMotion/AcsMotion.substitutions
+++ b/iocs/acsMotionIOC/iocBoot/iocAcsMotion/AcsMotion.substitutions
@@ -132,6 +132,7 @@ pattern
 #}
 
 ### The following databases are useful if programs are running on the ACS controller
+## PINI can be set to YES for IOCs that use autosave so that global var output records initialize properly
 #file "$(TOP)/db/SPiiPlusIntVar.db"
 #{
 #pattern
@@ -139,6 +140,7 @@ pattern
 #{c0:1001I,  "Int 1",    ACS1,  1001}
 #}
 #
+## PINI can be set to YES for IOCs that use autosave so that global var output records initialize properly
 #file "$(TOP)/db/SPiiPlusRealVar.db"
 #{
 #pattern


### PR DESCRIPTION
Allow PINI to be specified for global var output records, so that they initialize properly in IOCs with autosave.

Fixes #37 