### PR TITLE
vxWorks version 6.9 doesn't support lround

### DIFF
--- a/acsMotionApp/src/Makefile
+++ b/acsMotionApp/src/Makefile
@@ -8,7 +8,7 @@ include $(TOP)/configure/CONFIG
 
 DBD += AcsMotionSupport.dbd
 
-LIBRARY_IOC_Default = AcsMotion
+LIBRARY_IOC_DEFAULT = AcsMotion
 LIBRARY_IOC_vxWorks = -nil-
 
 SRCS += SPiiPlusBinComm.cpp

--- a/acsMotionApp/src/Makefile
+++ b/acsMotionApp/src/Makefile
@@ -8,7 +8,8 @@ include $(TOP)/configure/CONFIG
 
 DBD += AcsMotionSupport.dbd
 
-LIBRARY_IOC = AcsMotion
+LIBRARY_IOC_Default = AcsMotion
+LIBRARY_IOC_vxWorks = -nil-
 
 SRCS += SPiiPlusBinComm.cpp
 SRCS += SPiiPlusCommDriver.cpp


### PR DESCRIPTION
Eliminates AcsMotion builds for vxWorks.

AcsMotion relies on the lround function which is not available in the version of vxWorks we have. And as far as I can tell, it is not recommended to roll your own rounding function for floating point values.

Would fix #47 