### PR TITLE
Proposed change for MRES divisor issue

### DIFF
--- a/acsMotionApp/src/SPiiPlusDriver.cpp
+++ b/acsMotionApp/src/SPiiPlusDriver.cpp
@@ -155,6 +155,10 @@ SPiiPlusController::SPiiPlusController(const char* ACSPortName, const char* asyn
 			// Use the stepper factor as the resolution for stepper motors
 			pAxes_[index]->resolution_ = stepperFactor_[index];
 		}
+		else if ((pAxes_[index]->stepper_ == 0) &&  (pAxes_[index]->linear_ == 0) && (stepperFactor_[index] > 0))
+                {
+                        pAxes_[index]->resolution_ = stepperFactor_[index];
+                }
 		else
 		{
 			// Use the encoder factor as the resolution for brushless and linear motors


### PR DESCRIPTION
We could use STEPF for DC servo's with encoders.  Obviously we wouldn't normally set this in the proprietary setup.

MRES when the config for EFAC > UEIP @ 0.00029 and subsequently MRES against units configured as mm and not micron as a granular resolution can cause problems when moving 5.00mm to 5.51mm then subsequently 5.55mm.