### PR TITLE
Allow disabling setPosition

### DIFF
--- a/acsMotionApp/Db/Makefile
+++ b/acsMotionApp/Db/Makefile
@@ -28,6 +28,7 @@ DB += SPiiPlusRealVar.db
 DB += SPiiPlusProgram.db
 DB += SPiiPlusAxisExtra.db
 DB += SPiiPlusFeedback.db
+DB += SPiiPlusDisableSetPos.db
 DB += SPiiPlusTest.db
 
 #----------------------------------------------------

--- a/acsMotionApp/Db/SPiiPlusDisableSetPos.db
+++ b/acsMotionApp/Db/SPiiPlusDisableSetPos.db
@@ -1,0 +1,16 @@
+record(bo,"$(P)$(M):disableSetPos") {
+    field(DESC, "Disable set position")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR))SPIIPLUS_DISABLE_SET_POS")
+    field(ZNAM, "Off")
+    field(ONAM, "On")
+    field(VAL,  1)
+    field(PINI, "YES")
+}
+
+# Also tell autosave to never restore the position, which is redundant
+# NOTE: this only takes effect if RSTM hasn't been autosaved yet
+record(motor,"$(P)$(M)") {
+    field(RSTM, "Never")
+}
+

--- a/acsMotionApp/src/SPiiPlusDriver.h
+++ b/acsMotionApp/src/SPiiPlusDriver.h
@@ -141,7 +141,9 @@
 #define SPiiPlusHomingOffsetNegString          "SPIIPLUS_HOMING_OFFSET_NEG"
 #define SPiiPlusHomingCurrLimitString          "SPIIPLUS_HOMING_CURR_LIMIT"
 //
-#define SPiiPlusTestString                      "SPIIPLUS_TEST"
+#define SPiiPlusDisableSetPosString            "SPIIPLUS_DISABLE_SET_POS"
+//
+#define SPiiPlusTestString                     "SPIIPLUS_TEST"
 
 struct SPiiPlusDrvUser_t {
     const char *programName;
@@ -285,6 +287,8 @@ protected:
 	int SPiiPlusHomingOffsetPos_;
 	int SPiiPlusHomingOffsetNeg_;
 	int SPiiPlusHomingCurrLimit_;
+	//
+	int SPiiPlusDisableSetPos_;
 	//
 	int SPiiPlusTest_;
 	#define LAST_SPIIPLUS_PARAM SPiiPlusTest_

--- a/iocs/acsMotionIOC/iocBoot/iocAcsMotion/AcsMotion.substitutions
+++ b/iocs/acsMotionIOC/iocBoot/iocAcsMotion/AcsMotion.substitutions
@@ -45,6 +45,21 @@ pattern
 {pm1:,  8,    2000,      2000, ACS1,    7,     2.0,    4}
 }
 
+### Uncomment the following to disable setting the position for axes with absolute encoders
+#!file "$(TOP)/db/SPiiPlusDisableSetPos.db"
+#!{
+#!pattern
+#!{M,   PORT, ADDR}
+#!{m1,  ACS1,    0}
+#!{m2,  ACS1,    1}
+#!{m3,  ACS1,    2}
+#!{m4,  ACS1,    3}
+#!{m5,  ACS1,    4}
+#!{m6,  ACS1,    5}
+#!{m7,  ACS1,    6}
+#!{m8,  ACS1,    7}
+#!}
+
 file "$(TOP)/db/SPiiPlusAxisExtra.db"
 {
 pattern


### PR DESCRIPTION
Allow disabling the setting of the controller's position, which can be useful for axes with absolute encoders.